### PR TITLE
feat(cz_cz_ai.py): ollama integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,15 @@
 
 # 🤖 AI Commitizen Plugin
 
-A [Commitizen](https://github.com/commitizen-tools/commitizen) plugin that leverages OpenAI's GPT-4o to automatically generate clear, concise, and conventional commit messages based on your staged git changes.
+A [Commitizen](https://github.com/commitizen-tools/commitizen) plugin that leverages OpenAI's GPT-4o and local LLMs from Ollama to automatically generate clear, concise, and conventional commit messages based on your staged git changes.
 
 ## Features
 
-- Analyzes your staged diffs using OpenAI GPT-4o
+- Analyzes your staged diffs using OpenAI GPT-4o or any LLM from Ollama
 - Generates commit messages that follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
 - Suggests high-quality messages instantly to save time
 - Seamlessly integrates with existing Commitizen workflows
-- Choose your preferred OpenAI model (gpt-4o-mini, gpt-4o, etc.)
+- Choose your preferred OpenAI model (gpt-4o-mini, gpt-4o, etc.) or locally installed Ollama model
 
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,3 @@
-[![PyPI](https://img.shields.io/pypi/v/cz-ai?label=pypi)](https://pypi.org/project/cz-ai/)
-
-# 🤖 AI Commitizen Plugin
-
 <h3 align="center">
   🤖 AI Commitizen Plugin
 </h3>

--- a/README.md
+++ b/README.md
@@ -97,14 +97,21 @@ twine upload dist/*
 
 Adrian C ([watadarkstar](https://github.com/watadarkstar/))
 
-## Credits
-
-Generated using this template: https://github.com/commitizen-tools/commitizen_cz_template
-
 ## 📄 License
 
 This project is licensed under the [MIT License](LICENSE).  
 Feel free to use, modify, and distribute it as needed.
+
+## Credits
+
+Generated using this template: https://github.com/commitizen-tools/commitizen_cz_template
+
+### Github Contributors
+
+Thanks to these awesome contributors and many more! 🧘
+
+[![](https://github.com/watadarkstar.png?size=50)](https://github.com/watadarkstar)
+[![](https://github.com/dcvdiego.png?size=50)](https://github.com/dcvdiego)
 
 ---
 

--- a/cz_cz_ai.py
+++ b/cz_cz_ai.py
@@ -4,100 +4,183 @@ import subprocess
 import json
 from pathlib import Path
 from prompt_toolkit import prompt
+import requests
+import re
 
-MAX_DIFF_LENGTH = 8000
-MAX_TOKENS = 200
+MAX_DIFF_LENGTH = 16000
+MAX_TOKENS = 600
+
 class Cz_aiCz(BaseCommitizen):
+    def get_ollama_models(self) -> list:
+        """Fetches the list of locally installed Ollama models."""
+        try:
+            response = requests.get("http://localhost:11434/api/tags")
+            response.raise_for_status()
+            models_data = response.json().get("models", [])
+            return [model["name"] for model in models_data]
+        except requests.exceptions.ConnectionError:
+            print("\nWarning: Could not connect to Ollama to fetch model list.")
+            return []
+        except Exception as e:
+            print(f"\nWarning: An error occurred while fetching Ollama models: {e}")
+            return []
+
     def questions(self) -> list:
         api_key = self.get_open_ai_key()
-        return [
+        
+        questions = [
+            {
+                "type": "list",
+                "name": "ai_provider",
+                "message": "Which AI provider would you like to use?",
+                "choices": ["openai", "ollama"],
+                "default": "openai",
+            },
             {
                 "type": "input",
                 "name": "openai_api_key",
                 "message": "Please enter your OpenAI API Key:",
                 "default": api_key if api_key else "",
-            },
-            {
-                "type": "input",
-                "name": "model",
-                "message": "Which OpenAI model would you like to use:",
-                "default": "gpt-4o-mini",
-            },
+                "when": lambda answers: answers.get("ai_provider") == "openai",
+            }
         ]
 
-    def message(self, answers: dict) -> str:
-        print("Generating commit message using OpenAI's GPT-4o...")
-
-        # Try to get API key from cache first
-        cache_dir = Path.cwd() / ".commitizen"
-        cache_file = cache_dir / "openai_cache.json"
-        cache_api_key = self.get_open_ai_key()
-        api_key = answers.get("openai_api_key")
-        model = answers.get("model", "gpt-4o-mini")
+        ollama_models = self.get_ollama_models()
         
-        # Update the cache if the API key has changed
-        if cache_api_key != api_key and api_key:
-            with open(cache_file, 'w') as f:
-                json.dump({'openai_api_key': api_key}, f)
+        if ollama_models:
+            model_question = {
+                "type": "list",
+                "name": "model",
+                "message": "Which Ollama model would you like to use:",
+                "choices": ollama_models,
+                "when": lambda answers: answers.get("ai_provider") == "ollama",
+            }
+        else:
+            model_question = {
+                "type": "input",
+                "name": "model",
+                "message": "Which model would you like to use (Ollama connection failed):",
+                "default": "llama3",
+                "when": lambda answers: answers.get("ai_provider") == "ollama",
+            }
+        
+        questions.append(model_question)
 
-        # Authenticate with OpenAI API
-        openai.api_key = api_key
+        questions.append({
+            "type": "input",
+            "name": "model",
+            "message": "Which OpenAI model would you like to use:",
+            "default": "gpt-4o-mini",
+            "when": lambda answers: answers.get("ai_provider") == "openai",
+        })
 
-        print(f"Using OpenAI API Key: {openai.api_key}\n\n")
+        return questions
+
+    def message(self, answers: dict) -> str:
+        provider = answers.get("ai_provider")
+        model = answers.get("model")
+        
+        print(f"Generating commit message using {provider} with model {model}...")
 
         git_diff = subprocess.check_output(["git", "diff", "--staged"])
+        decoded_diff = git_diff.decode('utf-8')
 
-        print(f"Git diff: {git_diff}\n\n")
-
-        # Check if diff length is too large
         if len(git_diff) > MAX_DIFF_LENGTH:
             print("The diff is too large to write a commit message.")
             exit()
 
-        # Prepare prompt for OpenAI in Conventional Commits style
-        ai_prompt = f"Please generate a commit message in Conventional Commits style for the following changes:\n\n{git_diff.decode('utf-8')}\n\nType 'feat' for a new feature, 'fix' for a bug fix, 'docs' for documentation updates, 'style' for code style changes, 'refactor' for code refactoring, 'test' for test updates, 'chore' for build and tooling updates, or 'other' for any other changes:"
+        if provider == "openai":
+            api_key = answers.get("openai_api_key")
+            self.handle_openai_cache(api_key)
+            openai.api_key = api_key
+            commit_message = self.get_openai_commit_message(model, decoded_diff)
+        elif provider == "ollama":
+            commit_message = self.get_ollama_commit_message(model, decoded_diff)
+        else:
+            print("Invalid AI provider selected.")
+            exit()
 
-        # Generate text with OpenAI's GPT-4o
-        response = openai.chat.completions.create(
-            model=model,
-            messages=[
-                {"role": "system", "content": "You are a helpful assistant that generates commit messages in Conventional Commits style. Do not include any markdown."},
-                {"role": "user", "content": ai_prompt}
-            ],
-            max_tokens=MAX_TOKENS,
-            temperature=0.7,
-            n=3  # Generate 5 different responses
-        )
-
-        # Display all available choices
-        print("Available commit messages:")
-        for i, choice in enumerate(response.choices):
-            print(f"\n{i + 1}. {choice.message.content}")
-        
-        # Ask user to select a message
-        commit_message = None
-        while True:
-            try:
-                selection = int(input("\nPlease select a commit message (enter number) [1]: ") or "1")
-                if 1 <= selection <= len(response.choices):
-                    commit_message = response.choices[selection - 1].message.content
-                    break
-                else:
-                    print(f"Please enter a number between 1 and {len(response.choices)}")
-            except ValueError:
-                print("Please enter a valid number")
-        
         print(f"\nSelected commit message:\n\n{commit_message}\n\n")
         
-        # Ask user if they want to accept the message
         response = input("Is this auto-generated commit message OK? (Y/n): ").lower()
         
         if response == 'n':
-            # Let user modify the message
             modified_message = prompt("Please enter your modified commit message: ", default=commit_message)
             return modified_message.strip()
             
         return commit_message.strip()
+
+    def get_openai_commit_message(self, model, diff_text):
+        system_prompt = "You are an expert at writing Conventional Commits. Your response must be only the raw text of the commit message. You never include explanations or markdown formatting."
+        user_prompt = f"Generate a Conventional Commit message for the following git diff:\n\n{diff_text}"
+        
+        response = openai.chat.completions.create(
+            model=model,
+            messages=[
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": user_prompt}
+            ],
+            max_tokens=MAX_TOKENS,
+            temperature=0.7,
+            n=3
+        )
+
+        print("Available commit messages:")
+        for i, choice in enumerate(response.choices):
+            print(f"\n{i + 1}. {choice.message.content}")
+        
+        while True:
+            try:
+                selection = int(input("\nPlease select a commit message (enter number) [1]: ") or "1")
+                if 1 <= selection <= len(response.choices):
+                    return response.choices[selection - 1].message.content
+                else:
+                    print(f"Please enter a number between 1 and {len(response.choices)}")
+            except ValueError:
+                print("Please enter a valid number")
+
+    def get_ollama_commit_message(self, model, diff_text):
+        """
+        Gets a commit message from Ollama and strips the <think> block.
+        """
+        system_prompt = "You are an expert at writing Conventional Commits. You are a robot that ONLY outputs the raw text of a valid commit message and nothing else. You never explain your reasoning. You never use markdown. Your entire response is the commit message."
+        user_prompt = f"Generate a Conventional Commit message for the following git diff:\n\n{diff_text}"
+
+        try:
+            response = requests.post(
+                "http://localhost:11434/api/chat",
+                json={
+                    "model": model,
+                    "messages": [
+                        {"role": "system", "content": system_prompt},
+                        {"role": "user", "content": user_prompt}
+                    ],
+                    "stream": False,
+                    "options": {
+                        "num_predict": MAX_TOKENS,
+                        "temperature": 0.7
+                    }
+                },
+                timeout=60
+            )
+            response.raise_for_status()
+            
+            response_data = response.json()
+            raw_response = response_data.get("message", {}).get("content", "").strip()
+            
+            # Use regex to find and remove the entire <think>...</think> block
+            # re.DOTALL makes '.' match newlines, in case the block spans multiple lines
+            commit_message = re.sub(r"<think>.*?</think>", "", raw_response, flags=re.DOTALL).strip()
+            
+            return commit_message
+
+        except requests.exceptions.ConnectionError:
+            print("\nError: Could not connect to Ollama.")
+            print("Please ensure Ollama is running on your local machine at http://localhost:11434")
+            exit()
+        except requests.exceptions.RequestException as e:
+            print(f"\nAn error occurred with Ollama: {e}")
+            exit()
     
     def get_open_ai_key(self):
         cache_dir = Path.cwd() / ".commitizen"
@@ -108,6 +191,18 @@ class Cz_aiCz(BaseCommitizen):
         
         if cache_file.exists():
             with open(cache_file, 'r') as f:
-                cache = json.load(f)
-                return cache.get('openai_api_key')
+                try:
+                    cache = json.load(f)
+                    return cache.get('openai_api_key')
+                except json.JSONDecodeError:
+                    return None
         return None
+
+    def handle_openai_cache(self, new_api_key):
+        cache_dir = Path.cwd() / ".commitizen"
+        cache_file = cache_dir / "openai_cache.json"
+        cached_key = self.get_open_ai_key()
+
+        if cached_key != new_api_key and new_api_key:
+            with open(cache_file, 'w') as f:
+                json.dump({'openai_api_key': new_api_key}, f)

--- a/cz_cz_ai.py
+++ b/cz_cz_ai.py
@@ -8,7 +8,7 @@ import requests
 import re
 
 MAX_DIFF_LENGTH = 8000
-MAX_TOKENS = 600
+MAX_TOKENS = 200
 
 class Cz_aiCz(BaseCommitizen):
     def get_ollama_models(self) -> list:
@@ -176,7 +176,6 @@ class Cz_aiCz(BaseCommitizen):
                     ],
                     "stream": False,
                     "options": {
-                        "num_predict": MAX_TOKENS,
                         "temperature": 0.7
                     }
                 },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cz_ai"
-version = "0.7.8"
+version = "0.8.0"
 description = "A Commitizen plugin that leverages OpenAI's GPT-4o to automatically generate clear, concise, and conventional commit messages based on your staged git changes."
 readme = "README.md"
 requires-python = ">=3.7"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 openai==1.65.5
 prompt_toolkit==3.0.51
 requests==2.32.5
+commitizen==4.8.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 openai==1.65.5
-subprocess
-prompt_toolkit=3.0.51
+prompt_toolkit==3.0.51

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 openai==1.65.5
 prompt_toolkit==3.0.51
+requests==2.32.5


### PR DESCRIPTION
<img width="1655" height="240" alt="image" src="https://github.com/user-attachments/assets/0625fba7-b121-493a-bc7c-4da95888f2f9" />

Refer to #3 for more information.

This has made me think about how if modularity with different AI providers (GPT, Ollama) is now a part of the plugin, that maybe we should also provide a config file for things like max tokens, temperature, max diff length, and even prompt since I think with AI, the optional body in Conventional Commits can become a natural part of this tool. This can of course be another PR/issue.